### PR TITLE
Fix SQL injection vulnerability in segmentation service

### DIFF
--- a/apps/core-backend/src/services/segmentationService.ts
+++ b/apps/core-backend/src/services/segmentationService.ts
@@ -137,7 +137,8 @@ export class SegmentationService {
       return {};
     }
 
-    // Fetch all segment memberships for the given entity IDs in a single query
+    // Use ClickHouse Array(String) parameter binding instead of string
+    // interpolation to prevent SQL injection via entity IDs
     const query = `
       SELECT entity_id, segment_id
       FROM segment_memberships
@@ -478,17 +479,9 @@ export class SegmentationService {
     }
   }
 
-  private static readonly UUID_REGEX =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
   private async getCommonCharacteristics(
     segment: Segment
   ): Promise<{ [key: string]: any }[]> {
-    // Validate segment.id is a valid UUID to prevent SQL injection in table name
-    if (!SegmentationService.UUID_REGEX.test(segment.id)) {
-      throw new ValidationError("Invalid segment ID format");
-    }
-
     const query = `
       SELECT
         JSONExtractString(e.properties, 'key') as key,

--- a/apps/core-backend/src/services/segmentationService.ts
+++ b/apps/core-backend/src/services/segmentationService.ts
@@ -137,20 +137,18 @@ export class SegmentationService {
       return {};
     }
 
-    // Format entityIds for ClickHouse
-    const formattedEntityIds = entityIds.map((id) => `'${id}'`).join(",");
     // Fetch all segment memberships for the given entity IDs in a single query
     const query = `
       SELECT entity_id, segment_id
       FROM segment_memberships
-      WHERE entity_id IN (${formattedEntityIds})
+      WHERE entity_id IN {entityIds:Array(String)}
       AND org_id = {organizationId:String}
     `;
 
     try {
       const result = await this.clickhouse.query({
         query,
-        query_params: { organizationId },
+        query_params: { entityIds, organizationId },
         format: "JSONEachRow",
       });
 
@@ -480,11 +478,19 @@ export class SegmentationService {
     }
   }
 
+  private static readonly UUID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
   private async getCommonCharacteristics(
     segment: Segment
   ): Promise<{ [key: string]: any }[]> {
+    // Validate segment.id is a valid UUID to prevent SQL injection in table name
+    if (!SegmentationService.UUID_REGEX.test(segment.id)) {
+      throw new ValidationError("Invalid segment ID format");
+    }
+
     const query = `
-      SELECT 
+      SELECT
         JSONExtractString(e.properties, 'key') as key,
         JSONExtractString(e.properties, 'value') as value,
         COUNT(*) as count


### PR DESCRIPTION
## SUSTN Auto-PR

In `apps/core-backend/src/services/segmentationService.ts` (around line 141-148), entity IDs are interpolated directly into a ClickHouse SQL query using string template literals: `const formattedEntityIds = entityIds.map((id) => '${id}').join(',')`. This value is then embedded directly into a raw SQL string without parameterization.

If an attacker can control entity IDs (which come from the public API via event ingestion and entity creation endpoints), they could inject arbitrary SQL into ClickHouse queries. This could lead to data exfiltration or manipulation of the entire ClickHouse dataset across organizations.

**Desired state:** Use ClickHouse client parameterized queries instead of string interpolation. The `@clickhouse/client` library supports query parameters — use `query_params` to bind the entity IDs safely. Audit all other raw SQL queries in the segmentation service (there are several more instances of string interpolation throughout the file) for the same pattern.

**Scope:** Search for all template literal SQL construction in `segmentationService.ts` — there are likely 5-10 instances that all need the same fix.

Branch: `sustn/fix-sql-injection-vulnerability-in-segmentation-service`