### PR TITLE
Fix hardcoded encryption key and console-logged JWT secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ DB_PASSWORD=your_database_password
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 
+# Encryption key for messaging profile credentials (64-char hex string, i.e. 32 bytes)
+# Generate with: openssl rand -hex 32
+ENCRYPTION_KEY=
+
 # JWT secret key for authentication
 JWT_SECRET=your-secret-key
 

--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,10 @@ DB_PASSWORD=your_database_password
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 
-# Encryption key for messaging profile credentials (64-char hex string, i.e. 32 bytes)
-# Generate with: openssl rand -hex 32
+# Encryption key used to encrypt/decrypt sensitive messaging profile credentials
+# (e.g., SMTP passwords, API keys for email providers) stored in the database.
+# Must be a 64-character hex string (representing 32 bytes for AES-256).
+# Generate one by running: openssl rand -hex 32
 ENCRYPTION_KEY=
 
 # JWT secret key for authentication

--- a/apps/core-backend/src/services/authenticationService.ts
+++ b/apps/core-backend/src/services/authenticationService.ts
@@ -91,7 +91,6 @@ export class AuthService {
   }
 
   private generateToken(userId: string): string {
-    console.log("AppConfig.jwtSecret", AppConfig.jwtSecret);
     return jwt.sign({ userId }, AppConfig.jwtSecret, { expiresIn: "1d" });
   }
 

--- a/apps/core-backend/src/services/messagingProfileService.ts
+++ b/apps/core-backend/src/services/messagingProfileService.ts
@@ -13,12 +13,13 @@ export class MessagingProfileService {
   private encryptionKey: Buffer;
 
   constructor() {
-    this.encryptionKey = Buffer.from(
-      // TODO: move to env
-      process.env.ENCRYPTION_KEY ||
-        "5ebe2294ecd0e0f08eab7690d2a6ee69f9e5da618d6fea9f7c3d04c0cb180fc1",
-      "hex"
-    );
+    const key = process.env.ENCRYPTION_KEY;
+    if (!key) {
+      throw new Error(
+        "ENCRYPTION_KEY environment variable is required but not set"
+      );
+    }
+    this.encryptionKey = Buffer.from(key, "hex");
   }
 
   private encryptValue(value: string): string {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -20,7 +20,7 @@ const configSchema = z.object({
     user: z.string(),
     password: z.string(),
   }),
-  jwtSecret: z.string().min(1, "JWT_SECRET environment variable is required"),
+  jwtSecret: z.string().default("your-default-secret-key"),
   google: z.object({
     clientId: z.string(),
     clientSecret: z.string(),
@@ -94,7 +94,7 @@ const config = {
     clientId: env("GOOGLE_CLIENT_ID"),
     clientSecret: env("GOOGLE_CLIENT_SECRET"),
   },
-  jwtSecret: env("JWT_SECRET"),
+  jwtSecret: env("JWT_SECRET", "your-default-secret-key"),
   appUrl: env("APP_URL", "http://localhost:3000"),
   enforceSubscriptions:
     env("ENFORCE_SUBSCRIPTIONS", "true").toLowerCase() !== "false",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -20,7 +20,7 @@ const configSchema = z.object({
     user: z.string(),
     password: z.string(),
   }),
-  jwtSecret: z.string().default("your-default-secret-key"),
+  jwtSecret: z.string().min(1, "JWT_SECRET environment variable is required"),
   google: z.object({
     clientId: z.string(),
     clientSecret: z.string(),
@@ -94,7 +94,7 @@ const config = {
     clientId: env("GOOGLE_CLIENT_ID"),
     clientSecret: env("GOOGLE_CLIENT_SECRET"),
   },
-  jwtSecret: env("JWT_SECRET", "your-default-secret-key"),
+  jwtSecret: env("JWT_SECRET"),
   appUrl: env("APP_URL", "http://localhost:3000"),
   enforceSubscriptions:
     env("ENFORCE_SUBSCRIPTIONS", "true").toLowerCase() !== "false",

--- a/render.yaml
+++ b/render.yaml
@@ -18,6 +18,8 @@ services:
     buildCommand: "npm install; echo $NODE_VERSION; echo $DATABASE_URL; npx turbo run migrate:dev --filter=core-backend; npx turbo run build --filter=core-backend..."
     startCommand: node apps/core-backend/dist/cli/clickhouse.js -- setup; node apps/core-backend/dist/index.js
     envVars:
+      - key: ENCRYPTION_KEY
+        sync: false
       - key: ANTHROPIC_API_KEY
         sync: false
       - key: DATABASE_URL


### PR DESCRIPTION
## SUSTN Auto-PR

There are two critical security vulnerabilities that would allow an attacker to compromise the system:

1. **Hardcoded encryption key** in `apps/core-backend/src/services/messagingProfileService.ts` (around line 16-19): The encryption key used to encrypt messaging profile credentials (e.g., SMTP passwords, API keys for email providers) has a hardcoded fallback value `5ebe2294ecd0e0f08eab7690d2a6ee69f9e5da618d6fea9f7c3d04c0cb180fc1`. There's even a TODO comment acknowledging this. If the `ENCRYPTION_KEY` environment variable is not set, all credentials are encrypted with this publicly-visible key. Anyone with access to this repo can decrypt every stored credential.

2. **JWT secret logged to console** in `apps/core-backend/src/services/authenticationService.ts` (around line 94): `console.log('AppConfig.jwtSecret', AppConfig.jwtSecret)` prints the JWT signing secret to stdout on every authentication. Combined with the default JWT secret `your-default-secret-key` in `packages/config/src/config.ts`, an attacker could forge authentication tokens.

**Desired state:** Remove the hardcoded encryption key fallback entirely — the app should fail to start if `ENCRYPTION_KEY` is not set. Remove the console.log of the JWT secret. Remove the default value for `jwtSecret` in the config schema or replace it with a startup check that requires the env var in production. Add `ENCRYPTION_KEY` to `.env.example` and the Render env group.

**Watch out for:** Existing encrypted credentials in the database were encrypted with whatever key was active. If you change the key, you'll need a migration to re-encrypt existing credentials.

Branch: `sustn/fix-hardcoded-encryption-key-and-console-logged-jwt-secret`