### PR TITLE
Event handler swallows errors — failed journey triggers are silently lost

### DIFF
--- a/apps/core-backend/package.json
+++ b/apps/core-backend/package.json
@@ -97,6 +97,12 @@
       "node_modules",
       "src"
     ],
+    "moduleNameMapper": {
+      "^@lime/config$": "<rootDir>/../../packages/config/src/config.ts",
+      "^@lime/telemetry/logger$": "<rootDir>/../../packages/telemetry/src/logger.ts",
+      "^@lime/telemetry/(.*)$": "<rootDir>/../../packages/telemetry/src/$1.ts",
+      "^@lime/errors$": "<rootDir>/../../packages/errors/src/index.ts"
+    },
     "setupFiles": [
       "<rootDir>/src/__tests__/setupTests.ts"
     ]

--- a/apps/core-backend/src/__tests__/lib/eventRetry.test.ts
+++ b/apps/core-backend/src/__tests__/lib/eventRetry.test.ts
@@ -1,0 +1,228 @@
+// Mock dependencies before imports
+jest.mock("@lime/config", () => ({
+  AppConfig: {
+    eventQueue: { type: "simple" },
+  },
+}));
+
+jest.mock("@lime/telemetry/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../../services/entitiesService", () => ({}));
+
+import {
+  EventQueueService,
+  EventType,
+  TriggerJourneyEvent,
+  RetryConfig,
+} from "../../lib/queue";
+
+const { logger } = jest.requireMock("@lime/telemetry/logger");
+
+describe("EventQueueService retry and dead-letter logic", () => {
+  let service: EventQueueService;
+
+  const retryConfig: RetryConfig = {
+    maxRetries: 2,
+    baseDelayMs: 10,
+    maxDelayMs: 50,
+  };
+
+  beforeEach(() => {
+    EventQueueService.resetInstance();
+    service = EventQueueService.getInstance(retryConfig);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    EventQueueService.resetInstance();
+  });
+
+  const makeTriggerEvent = (): TriggerJourneyEvent => ({
+    type: EventType.TRIGGER_JOURNEY,
+    organizationId: "org-1",
+    timestamp: new Date().toISOString(),
+    entityId: "entity-1",
+    journeyId: "journey-1",
+    eventName: "test-event",
+    eventProperties: { key: "value" },
+    entityData: {} as any,
+  });
+
+  describe("executeWithRetry", () => {
+    it("should call handler once on success", async () => {
+      const handler = jest.fn().mockResolvedValue(undefined);
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(service.getFailedEventCount()).toBe(0);
+      expect(service.getDeadLetterQueue()).toHaveLength(0);
+    });
+
+    it("should retry on failure and succeed on subsequent attempt", async () => {
+      const handler = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("Temporal unavailable"))
+        .mockResolvedValue(undefined);
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(service.getRetriedEventCount()).toBe(1);
+      expect(service.getFailedEventCount()).toBe(0);
+      expect(service.getDeadLetterQueue()).toHaveLength(0);
+    });
+
+    it("should move event to DLQ after exhausting retries", async () => {
+      const handler = jest
+        .fn()
+        .mockRejectedValue(new Error("Persistent failure"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      // Initial attempt + 2 retries = 3 calls
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(service.getFailedEventCount()).toBe(1);
+      expect(service.getDeadLetterQueue()).toHaveLength(1);
+
+      const dlqEvent = service.getDeadLetterQueue()[0];
+      expect(dlqEvent.error).toBe("Persistent failure");
+      expect(dlqEvent.attempts).toBe(3);
+      expect(dlqEvent.event.type).toBe(EventType.TRIGGER_JOURNEY);
+    });
+
+    it("should log warnings on each retry attempt", async () => {
+      const handler = jest
+        .fn()
+        .mockRejectedValue(new Error("Temporary error"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      // 2 retries = 2 warn calls
+      const warnCalls = logger.warn.mock.calls.filter(
+        (call: any[]) =>
+          call[0] === "events" && call[1].includes("retrying in")
+      );
+      expect(warnCalls).toHaveLength(2);
+      expect(warnCalls[0][2]).toMatchObject({ attempt: 1 });
+    });
+
+    it("should log error when event is moved to DLQ", async () => {
+      const handler = jest.fn().mockRejectedValue(new Error("Fatal error"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      const errorCalls = logger.error.mock.calls.filter(
+        (call: any[]) =>
+          call[0] === "events" && call[1].includes("dead-letter queue")
+      );
+      expect(errorCalls).toHaveLength(1);
+      expect(errorCalls[0][3]).toMatchObject({ attempts: 3 });
+    });
+  });
+
+  describe("getEventMetrics", () => {
+    it("should return correct metrics", async () => {
+      const handler = jest
+        .fn()
+        .mockRejectedValue(new Error("Persistent failure"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+      await service.publish(makeTriggerEvent());
+
+      const metrics = service.getEventMetrics();
+      expect(metrics.failedEvents).toBe(2);
+      expect(metrics.retriedEvents).toBe(4); // 2 retries per event * 2 events
+      expect(metrics.deadLetterQueueSize).toBe(2);
+    });
+  });
+
+  describe("replayDeadLetterEvent", () => {
+    it("should replay a dead-letter event successfully", async () => {
+      const handler = jest
+        .fn()
+        .mockRejectedValue(new Error("Failure"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      expect(service.getDeadLetterQueue()).toHaveLength(1);
+
+      // Now make handler succeed for replay
+      handler.mockResolvedValue(undefined);
+      const result = await service.replayDeadLetterEvent(0);
+
+      expect(result).toBe(true);
+      expect(service.getDeadLetterQueue()).toHaveLength(0);
+    });
+
+    it("should return false for invalid index", async () => {
+      const result = await service.replayDeadLetterEvent(999);
+      expect(result).toBe(false);
+    });
+
+    it("should return false if replay fails", async () => {
+      const handler = jest
+        .fn()
+        .mockRejectedValue(new Error("Always fails"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+      await service.publish(makeTriggerEvent());
+
+      expect(service.getDeadLetterQueue()).toHaveLength(1);
+
+      // Handler still fails for replay
+      const result = await service.replayDeadLetterEvent(0);
+      expect(result).toBe(false);
+      expect(service.getDeadLetterQueue()).toHaveLength(1);
+    });
+  });
+
+  describe("exponential backoff", () => {
+    it("should cap delay at maxDelayMs", async () => {
+      EventQueueService.resetInstance();
+      const configWithManyRetries: RetryConfig = {
+        maxRetries: 5,
+        baseDelayMs: 10,
+        maxDelayMs: 50,
+      };
+      service = EventQueueService.getInstance(configWithManyRetries);
+
+      const handler = jest
+        .fn()
+        .mockRejectedValue(new Error("Failure"));
+
+      service.registerEventHandler(EventType.TRIGGER_JOURNEY, handler);
+      await service.initialize();
+
+      const start = Date.now();
+      await service.publish(makeTriggerEvent());
+      const elapsed = Date.now() - start;
+
+      // Capped delays: 10 + 20 + 40 + 50 + 50 = 170ms max, with timing variance
+      expect(elapsed).toBeLessThan(500);
+      expect(handler).toHaveBeenCalledTimes(6); // 1 initial + 5 retries
+    });
+  });
+});

--- a/apps/core-backend/src/controllers/private/eventsController.ts
+++ b/apps/core-backend/src/controllers/private/eventsController.ts
@@ -19,6 +19,7 @@ import type {
   JWTAuthenticatedUser,
 } from "../../models/auth";
 import { ApiResponse } from "../../models/apiResponse";
+import { EventQueueService, DeadLetterEvent } from "../../lib/queue";
 import type { EventData, RecordEventRequest } from "../../models/events";
 
 @Route("events")
@@ -166,36 +167,90 @@ export class EventController {
     }
   }
 
-  //   @Get("entity/:entityId")
-  //   @Response<ApiResponse<EventData[]>>(200, "Retrieved events for entity")
-  //   @Response<ApiResponse<null>>(500, "Internal Server Error")
-  //   public async getEventsByEntityId(
-  //     @Request() request: AuthenticatedRequest,
-  //     @Path() entityId: string,
-  //     @Res() serverErrorResponse: TsoaResponse<500, ApiResponse<null>>,
-  //     @Query() limit?: number,
-  //     @Query() offset?: number
-  //   ): Promise<ApiResponse<EventData[]> | void> {
-  //     try {
-  //       const user = request.user as JWTAuthenticatedUser;
-  //       const organizationId = user.currentOrganizationId as string;
-  //       const events = await this.eventService.getEventsByEntityId(
-  //         organizationId,
-  //         entityId,
-  //         limit,
-  //         offset
-  //       );
-  //       return {
-  //         status: "success",
-  //         data: events,
-  //         message: "Events for entity retrieved successfully",
-  //       };
-  //     } catch (error) {
-  //       return serverErrorResponse(500, {
-  //         status: "error",
-  //         data: null,
-  //         message: "An error occurred while retrieving events for the entity",
-  //       });
-  //     }
-  //   }
+  @Get("queue/metrics")
+  @Response<ApiResponse<null>>(500, "Internal Server Error")
+  public async getEventQueueMetrics(
+    @Request() request: AuthenticatedRequest,
+    @Res() serverErrorResponse: TsoaResponse<500, ApiResponse<null>>
+  ): Promise<
+    | ApiResponse<{
+        failedEvents: number;
+        retriedEvents: number;
+        deadLetterQueueSize: number;
+      }>
+    | void
+  > {
+    try {
+      const queueService = EventQueueService.getInstance();
+      const metrics = queueService.getEventMetrics();
+      return {
+        status: "success",
+        data: metrics,
+        message: "Event queue metrics retrieved successfully",
+      };
+    } catch (error) {
+      return serverErrorResponse(500, {
+        status: "error",
+        data: null,
+        message: "An error occurred while retrieving event queue metrics",
+      });
+    }
+  }
+
+  @Get("queue/dead-letter")
+  @Response<ApiResponse<null>>(500, "Internal Server Error")
+  public async getDeadLetterQueue(
+    @Request() request: AuthenticatedRequest,
+    @Res() serverErrorResponse: TsoaResponse<500, ApiResponse<null>>
+  ): Promise<ApiResponse<DeadLetterEvent[]> | void> {
+    try {
+      const queueService = EventQueueService.getInstance();
+      const deadLetterEvents = queueService.getDeadLetterQueue();
+      return {
+        status: "success",
+        data: deadLetterEvents,
+        message: "Dead-letter queue retrieved successfully",
+      };
+    } catch (error) {
+      return serverErrorResponse(500, {
+        status: "error",
+        data: null,
+        message: "An error occurred while retrieving the dead-letter queue",
+      });
+    }
+  }
+
+  @Post("queue/dead-letter/{index}/replay")
+  @Response<ApiResponse<null>>(400, "Bad Request")
+  @Response<ApiResponse<null>>(500, "Internal Server Error")
+  public async replayDeadLetterEvent(
+    @Path() index: number,
+    @Request() request: AuthenticatedRequest,
+    @Res() badRequestResponse: TsoaResponse<400, ApiResponse<null>>,
+    @Res() serverErrorResponse: TsoaResponse<500, ApiResponse<null>>
+  ): Promise<ApiResponse<{ replayed: boolean }> | void> {
+    try {
+      const queueService = EventQueueService.getInstance();
+      const success = await queueService.replayDeadLetterEvent(index);
+      if (!success) {
+        return badRequestResponse(400, {
+          status: "error",
+          data: null,
+          message:
+            "Failed to replay event. Index may be invalid or the handler failed.",
+        });
+      }
+      return {
+        status: "success",
+        data: { replayed: true },
+        message: "Dead-letter event replayed successfully",
+      };
+    } catch (error) {
+      return serverErrorResponse(500, {
+        status: "error",
+        data: null,
+        message: "An error occurred while replaying the dead-letter event",
+      });
+    }
+  }
 }

--- a/apps/core-backend/src/lib/eventHandler.ts
+++ b/apps/core-backend/src/lib/eventHandler.ts
@@ -7,6 +7,7 @@ import {
 } from "./queue";
 import { EventService } from "../services/eventsService";
 import { TemporalService } from "./temporal";
+import { logger } from "@lime/telemetry/logger";
 
 /**
  * EventHandler class manages the processing of various event types in the system.
@@ -112,33 +113,30 @@ export class EventHandler {
    */
   private handleJourneyTriggered = async (event: Event): Promise<void> => {
     if (event.type === EventType.TRIGGER_JOURNEY) {
-      //   await this.eventService.triggerJourney(event);
-      console.log(
-        "\x1b[1m%s\x1b[0m",
-        `Journey Triggered: ${JSON.stringify(event, null, 2)}`
+      logger.info(
+        "events",
+        `Journey Triggered: journeyId=${event.journeyId}, entityId=${event.entityId}`,
+        { journeyId: event.journeyId, entityId: event.entityId }
       );
 
-      try {
-        const temporalService = await TemporalService.getInstance();
+      const temporalService = await TemporalService.getInstance();
 
-        await temporalService.startOrContinueJourneyWorkflow({
-          journeyId: event.journeyId,
-          entityId: event.entityId,
-          organizationId: event.organizationId,
-          triggerEvent: {
-            eventName: event.eventName,
-            eventProperties: event.eventProperties,
-          },
-          entityData: event.entityData,
-        });
+      await temporalService.startOrContinueJourneyWorkflow({
+        journeyId: event.journeyId,
+        entityId: event.entityId,
+        organizationId: event.organizationId,
+        triggerEvent: {
+          eventName: event.eventName,
+          eventProperties: event.eventProperties,
+        },
+        entityData: event.entityData,
+      });
 
-        console.log(
-          `Started journey workflow for journey ${event.journeyId} and entity ${event.entityId}`
-        );
-      } catch (error) {
-        console.error(`Error starting journey workflow: ${error}`);
-        // Handle the error appropriately
-      }
+      logger.info(
+        "events",
+        `Started journey workflow for journey ${event.journeyId} and entity ${event.entityId}`,
+        { journeyId: event.journeyId, entityId: event.entityId }
+      );
     }
   };
 

--- a/apps/core-backend/src/lib/queue.ts
+++ b/apps/core-backend/src/lib/queue.ts
@@ -1,8 +1,27 @@
 import { Kafka, Producer, Consumer, KafkaMessage, logLevel } from "kafkajs";
-import { EventEmitter } from "events";
+
 import { AppConfig } from "@lime/config";
 import { logger } from "@lime/telemetry/logger";
 import { EntityData } from "../services/entitiesService";
+
+export interface RetryConfig {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface DeadLetterEvent {
+  event: Event;
+  error: string;
+  failedAt: string;
+  attempts: number;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+  maxRetries: 3,
+  baseDelayMs: 500,
+  maxDelayMs: 10000,
+};
 
 export enum EventType {
   ENTITY_CREATED = "ENTITY_CREATED",
@@ -74,17 +93,25 @@ interface IQueue {
   connect?(): Promise<void>;
 }
 
-class SimpleInMemoryEventQueue extends EventEmitter implements IQueue {
+class SimpleInMemoryEventQueue implements IQueue {
+  private handlers: Map<string, ((message: any) => void | Promise<void>)[]> =
+    new Map();
+
   async publish(topic: string, message: any): Promise<void> {
-    this.emit(topic, message);
+    const callbacks = this.handlers.get(topic) || [];
+    for (const callback of callbacks) {
+      await callback(message);
+    }
     logger.info("events", `Published message to topic: ${topic}`, { topic });
   }
 
   async subscribe(
     topic: string,
-    callback: (message: any) => void
+    callback: (message: any) => void | Promise<void>
   ): Promise<void> {
-    this.on(topic, callback);
+    const existing = this.handlers.get(topic) || [];
+    existing.push(callback);
+    this.handlers.set(topic, existing);
     logger.info("events", `Subscribed to topic: ${topic}`, { topic });
   }
 
@@ -200,8 +227,13 @@ class EventQueueService {
   private queue: IQueue;
   private eventHandlers: Map<EventType, (event: Event) => Promise<void>> =
     new Map();
+  private deadLetterQueue: DeadLetterEvent[] = [];
+  private retryConfig: RetryConfig;
+  private failedEventCount: number = 0;
+  private retriedEventCount: number = 0;
 
-  private constructor() {
+  private constructor(retryConfig?: RetryConfig) {
+    this.retryConfig = retryConfig ?? DEFAULT_RETRY_CONFIG;
     if (AppConfig.eventQueue.type === "kafka") {
       this.queue = new KafkaEventQueue();
       logger.info("events", "Initialized Kafka event queue");
@@ -211,16 +243,20 @@ class EventQueueService {
     }
   }
 
-  public static getInstance(): EventQueueService {
+  public static getInstance(retryConfig?: RetryConfig): EventQueueService {
     if (!EventQueueService.instance) {
-      EventQueueService.instance = new EventQueueService();
+      EventQueueService.instance = new EventQueueService(retryConfig);
       logger.info("events", "Created EventQueueService instance");
     }
     return EventQueueService.instance;
   }
 
+  /** Reset singleton — intended for tests only */
+  public static resetInstance(): void {
+    EventQueueService.instance = null;
+  }
+
   async initialize(): Promise<void> {
-    // if (this.queue instanceof KafkaEventQueue) {
     try {
       await this.queue.connect();
       logger.info("events", "EventQueueService initialized and connected");
@@ -233,7 +269,6 @@ class EventQueueService {
       );
       throw error;
     }
-    // }
   }
 
   async shutdown(): Promise<void> {
@@ -282,22 +317,139 @@ class EventQueueService {
   private async handleEvent(event: Event): Promise<void> {
     const handler = this.eventHandlers.get(event.type);
     if (handler) {
-      try {
-        await handler(event);
-      } catch (error) {
-        logger.error(
-          "events",
-          `Error processing event of type: ${event.type}`,
-          error as Error,
-          { eventType: event.type }
-        );
-      }
+      await this.executeWithRetry(event, handler);
     } else {
       logger.warn(
         "events",
         `No handler registered for event type: ${event.type}`,
         { eventType: event.type }
       );
+    }
+  }
+
+  private async executeWithRetry(
+    event: Event,
+    handler: (event: Event) => Promise<void>
+  ): Promise<void> {
+    const { maxRetries, baseDelayMs, maxDelayMs } = this.retryConfig;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await handler(event);
+        return;
+      } catch (error) {
+        const isLastAttempt = attempt === maxRetries;
+
+        if (isLastAttempt) {
+          this.sendToDeadLetterQueue(event, error as Error, maxRetries + 1);
+          return;
+        }
+
+        this.retriedEventCount++;
+        const delay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+        logger.warn(
+          "events",
+          `Event handler failed for ${event.type}, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})`,
+          {
+            eventType: event.type,
+            attempt: attempt + 1,
+            maxRetries,
+            delay,
+          }
+        );
+        await this.sleep(delay);
+      }
+    }
+  }
+
+  private sendToDeadLetterQueue(
+    event: Event,
+    error: Error,
+    attempts: number
+  ): void {
+    const deadLetterEvent: DeadLetterEvent = {
+      event,
+      error: error.message,
+      failedAt: new Date().toISOString(),
+      attempts,
+    };
+
+    this.deadLetterQueue.push(deadLetterEvent);
+    this.failedEventCount++;
+
+    logger.error(
+      "events",
+      `Event moved to dead-letter queue after ${attempts} attempts: ${event.type}`,
+      error,
+      {
+        eventType: event.type,
+        attempts,
+        deadLetterQueueSize: this.deadLetterQueue.length,
+      }
+    );
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  getDeadLetterQueue(): DeadLetterEvent[] {
+    return [...this.deadLetterQueue];
+  }
+
+  getFailedEventCount(): number {
+    return this.failedEventCount;
+  }
+
+  getRetriedEventCount(): number {
+    return this.retriedEventCount;
+  }
+
+  getEventMetrics(): {
+    failedEvents: number;
+    retriedEvents: number;
+    deadLetterQueueSize: number;
+  } {
+    return {
+      failedEvents: this.failedEventCount,
+      retriedEvents: this.retriedEventCount,
+      deadLetterQueueSize: this.deadLetterQueue.length,
+    };
+  }
+
+  async replayDeadLetterEvent(index: number): Promise<boolean> {
+    if (index < 0 || index >= this.deadLetterQueue.length) {
+      return false;
+    }
+
+    const deadLetterEvent = this.deadLetterQueue[index];
+    const handler = this.eventHandlers.get(deadLetterEvent.event.type);
+
+    if (!handler) {
+      logger.warn(
+        "events",
+        `No handler for dead-letter event type: ${deadLetterEvent.event.type}`
+      );
+      return false;
+    }
+
+    try {
+      await handler(deadLetterEvent.event);
+      this.deadLetterQueue.splice(index, 1);
+      logger.info(
+        "events",
+        `Successfully replayed dead-letter event: ${deadLetterEvent.event.type}`,
+        { eventType: deadLetterEvent.event.type }
+      );
+      return true;
+    } catch (error) {
+      logger.error(
+        "events",
+        `Failed to replay dead-letter event: ${deadLetterEvent.event.type}`,
+        error as Error,
+        { eventType: deadLetterEvent.event.type }
+      );
+      return false;
     }
   }
 


### PR DESCRIPTION
## SUSTN Auto-PR

In eventHandler.ts (lines 113-143), `handleJourneyTriggered` catches errors from `temporalService.startOrContinueJourneyWorkflow()` and only logs them with `console.error`. The function returns normally, so the event processing pipeline considers the event handled successfully. There's a comment saying '// Handle the error appropriately' indicating this is known-incomplete.

Similarly, in the Kafka/in-memory queue subscriber, errors in event handlers are caught and logged but events are not retried or sent to a dead-letter queue. This means: (1) if Temporal is temporarily unavailable, journey triggers are permanently lost, (2) there's no alerting mechanism, (3) no way to replay failed events.

The fix should: (1) implement retry logic with exponential backoff, (2) add a dead-letter mechanism for events that fail after retries, (3) surface failed event counts in the dashboard or monitoring.

Branch: `sustn/event-handler-swallows-errors-failed-journey-triggers-are-si`