### PR TITLE
Duplicate Temporal workflows can run concurrently for the same entity-journey pair

### DIFF
--- a/apps/core-backend/src/lib/temporal/temporalService.ts
+++ b/apps/core-backend/src/lib/temporal/temporalService.ts
@@ -3,6 +3,7 @@ import {
   Client,
   WorkflowHandle,
   WorkflowIdReusePolicy,
+  WorkflowExecutionAlreadyStartedError,
 } from "@temporalio/client";
 import { v4 as uuidv4 } from "uuid";
 import { AppConfig } from "@lime/config";
@@ -91,7 +92,7 @@ export class TemporalService {
         workflowRunTimeout: options.workflowRunTimeout,
         workflowIdReusePolicy:
           options.workflowIdReusePolicy ||
-          WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
+          WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
       });
       logger.info("temporal", `Started workflow ${workflowName}`, {
         workflowId,
@@ -114,6 +115,8 @@ export class TemporalService {
     return this.startWorkflow("JourneyWorkflow", params, {
       taskQueue: AppConfig.temporal.taskQueue,
       workflowId: `journey-${params.journeyId}-${params.entityId}`,
+      workflowIdReusePolicy:
+        WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
     });
   }
 
@@ -123,31 +126,24 @@ export class TemporalService {
     const workflowId = `journey-${params.journeyId}-${params.entityId}`;
 
     try {
-      // Try to fetch an existing workflow
-      const existingWorkflow = await this.client.workflow.getHandle(workflowId);
-      const status = await existingWorkflow.describe();
-
-      if (status.status.name === "RUNNING") {
-        logger.info("temporal", `Workflow ${workflowId} is already running`, {
-          workflowId,
-        });
-        return existingWorkflow;
-      }
-
-      // If workflow is completed or failed, start a new one
-      return this.startWorkflow("JourneyWorkflow", params, {
+      // Attempt to start with ALLOW_DUPLICATE_FAILED_ONLY policy.
+      // Temporal will atomically reject the start if a workflow with this ID
+      // is already running or completed successfully, preventing race conditions.
+      const handle = await this.startWorkflow("JourneyWorkflow", params, {
         taskQueue: AppConfig.temporal.taskQueue,
         workflowId: workflowId,
         workflowRunTimeout: "24 hours",
+        workflowIdReusePolicy:
+          WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY,
       });
+      return handle;
     } catch (error) {
-      // If workflow doesn't exist, start a new one
-      if (error instanceof Error && error.name === "WorkflowNotFoundError") {
-        return this.startWorkflow("JourneyWorkflow", params, {
-          taskQueue: AppConfig.temporal.taskQueue,
-          workflowId: workflowId,
-          workflowRunTimeout: "24 hours",
+      if (error instanceof WorkflowExecutionAlreadyStartedError) {
+        // Workflow is already running — return a handle to the existing one
+        logger.info("temporal", `Workflow ${workflowId} is already running`, {
+          workflowId,
         });
+        return this.client.workflow.getHandle(workflowId);
       }
       logger.error(
         "temporal",


### PR DESCRIPTION
## SUSTN Auto-PR

In temporalService.ts, `startOrContinueJourneyWorkflow()` attempts to check for existing workflows by calling `getHandle()` and `describe()`. However, there's a race condition: between checking and starting, another instance could start the same workflow. The `startWorkflow()` method uses Temporal's default `WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE`, which allows multiple concurrent workflows with the same ID.

This means if the same event triggers a journey for the same entity twice in quick succession (which can happen with fire-and-forget publishes), two workflow instances run simultaneously. Both send the same emails, track the same analytics, and update the same database records. Users receive duplicate communications.

The fix should set `workflowIdReusePolicy` to `WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE` or `WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY` when starting workflows, and add proper idempotency keys.

Branch: `sustn/duplicate-temporal-workflows-can-run-concurrently-for-the-sa`