### PR TITLE
Insecure default JWT secret and secret logged to console

### DIFF
--- a/apps/core-backend/src/services/authenticationService.ts
+++ b/apps/core-backend/src/services/authenticationService.ts
@@ -91,7 +91,6 @@ export class AuthService {
   }
 
   private generateToken(userId: string): string {
-    console.log("AppConfig.jwtSecret", AppConfig.jwtSecret);
     return jwt.sign({ userId }, AppConfig.jwtSecret, { expiresIn: "1d" });
   }
 

--- a/apps/core-backend/src/services/eventsService.ts
+++ b/apps/core-backend/src/services/eventsService.ts
@@ -289,8 +289,6 @@ export class EventService {
         `event:${eventName}:journeys:${event.organizationId}`
       );
 
-      console.log("Journey IDs284:", journeyIds);
-
       for (const journeyId of journeyIds) {
         this.eventQueueService.publish({
           type: EventType.TRIGGER_JOURNEY,

--- a/apps/core-backend/src/services/segmentationService.ts
+++ b/apps/core-backend/src/services/segmentationService.ts
@@ -1165,6 +1165,10 @@ export class SegmentationService {
     organizationId: string
   ): Promise<any> {
     try {
+      logger.debug("segmentation", `Getting entity data`, {
+        entityId,
+        organizationId,
+      });
       const query = `
         SELECT * FROM entities
         WHERE id = {entityId:String} AND org_id = {organizationId:String}

--- a/apps/core-backend/src/services/segmentationService.ts
+++ b/apps/core-backend/src/services/segmentationService.ts
@@ -1165,8 +1165,6 @@ export class SegmentationService {
     organizationId: string
   ): Promise<any> {
     try {
-      console.log("Getting entity data for entityId: ", entityId);
-      console.log("Getting entity data for organizationId: ", organizationId);
       const query = `
         SELECT * FROM entities
         WHERE id = {entityId:String} AND org_id = {organizationId:String}
@@ -1182,7 +1180,6 @@ export class SegmentationService {
       const entities = await result.json();
       return entities[0] || null;
     } catch (error) {
-      console.log("Error getting entity data: ", error);
       logger.error(
         "segmentation",
         `Failed to get entity data for entityId: ${entityId}`,

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -20,7 +20,7 @@ const configSchema = z.object({
     user: z.string(),
     password: z.string(),
   }),
-  jwtSecret: z.string().default("your-default-secret-key"),
+  jwtSecret: z.string().min(1, "JWT_SECRET environment variable must be set"),
   google: z.object({
     clientId: z.string(),
     clientSecret: z.string(),
@@ -94,7 +94,7 @@ const config = {
     clientId: env("GOOGLE_CLIENT_ID"),
     clientSecret: env("GOOGLE_CLIENT_SECRET"),
   },
-  jwtSecret: env("JWT_SECRET", "your-default-secret-key"),
+  jwtSecret: env("JWT_SECRET"),
   appUrl: env("APP_URL", "http://localhost:3000"),
   enforceSubscriptions:
     env("ENFORCE_SUBSCRIPTIONS", "true").toLowerCase() !== "false",


### PR DESCRIPTION
## SUSTN Auto-PR

Two critical security issues in the authentication system:

1. **Default JWT secret in production:** `packages/config/src/config.ts` line 69 sets `jwtSecret: env('JWT_SECRET', 'your-default-secret-key')`. If the `JWT_SECRET` environment variable is not set, the application falls back to a well-known default string. Any attacker who reads the source code (it's open source) can forge valid JWT tokens for any user, gaining full administrative access to any deployment that missed setting this variable.

2. **JWT secret logged to console:** `apps/core-backend/src/services/authenticationService.ts` contains `console.log('AppConfig.jwtSecret', AppConfig.jwtSecret)` in the `generateToken` method. This prints the JWT signing secret to stdout on every authentication attempt. In production, this could end up in log aggregation systems, monitoring dashboards, or third-party logging services, exposing the secret to anyone with log access.

**Fix:**
- Remove the default value for `JWT_SECRET` and make it a required field in the config schema. The application should fail to start if it's not set.
- Remove the `console.log` statement that leaks the secret.
- Audit for other `console.log` statements that may leak sensitive data (there are several debug `console.log` calls throughout `eventsService.ts` line 292 and `segmentationService.ts` lines 1168-1169).

Branch: `sustn/insecure-default-jwt-secret-and-secret-logged-to-console`